### PR TITLE
Only send to logzio if a token has been set

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,20 @@ const logzioNodejs = require('logzio-nodejs');
 module.exports = main
 
 function main (stream, options) {
-  const logger = options.token ?
-        logzioNodejs.createLogger(options) :
-        null
+  if (!options.token) {
+    console.log('[pipe-to-logzio] no token')
+    stream.pipe(process.stdout)
+    return
+  }
+
+  const logger = logzioNodejs.createLogger(options)
 
   var myTransport = through(function (chunk, enc, cb) {
     const val = chunk.toString('utf8')
     console.log(val)
-    if (logger) { logger.log(stripAnsi(val)) }
+    logger.log(stripAnsi(val))
     cb()
   })
 
-  pump(stream, myTransport)
+  pump(stream, myTransport)  
 }

--- a/index.js
+++ b/index.js
@@ -6,12 +6,14 @@ const logzioNodejs = require('logzio-nodejs');
 module.exports = main
 
 function main (stream, options) {
-  const logger = logzioNodejs.createLogger(options)
+  const logger = options.token ?
+        logzioNodejs.createLogger(options) :
+        null
 
   var myTransport = through(function (chunk, enc, cb) {
     const val = chunk.toString('utf8')
     console.log(val)
-    logger.log(stripAnsi(val))
+    if (logger) { logger.log(stripAnsi(val)) }
     cb()
   })
 


### PR DESCRIPTION
This allows us to disable the logz.io integration (and just send logs to console as normal) by clearing the `--token` input.